### PR TITLE
Fix compiler error with latest compilers. (#1)

### DIFF
--- a/sophus/common.hpp
+++ b/sophus/common.hpp
@@ -210,22 +210,22 @@ class optional {
   explicit operator bool() const { return is_valid_; }
 
   T const* operator->() const {
-    SOPHUS_ENSURE(is_valid_, "must be valid");
+    SOPHUS_ENSURE(is_valid_, "%s", "must be valid");
     return &type_;
   }
 
   T* operator->() {
-    SOPHUS_ENSURE(is_valid_, "must be valid");
+    SOPHUS_ENSURE(is_valid_, "%s", "must be valid");
     return &type_;
   }
 
   T const& operator*() const {
-    SOPHUS_ENSURE(is_valid_, "must be valid");
+    SOPHUS_ENSURE(is_valid_, "%s", "must be valid");
     return type_;
   }
 
   T& operator*() {
-    SOPHUS_ENSURE(is_valid_, "must be valid");
+    SOPHUS_ENSURE(is_valid_, "%s", "must be valid");
     return type_;
   }
 

--- a/sophus/se2.hpp
+++ b/sophus/se2.hpp
@@ -660,7 +660,7 @@ class SE2 : public SE2Base<SE2<Scalar_, Options>> {
   /// Precondition: ``i`` must be in 0, 1 or 2.
   ///
   SOPHUS_FUNC static Transformation generator(int i) {
-    SOPHUS_ENSURE(i >= 0 || i <= 2, "i should be in range [0,2].");
+    SOPHUS_ENSURE(i >= 0 || i <= 2, "%s", "i should be in range [0,2].");
     Tangent e;
     e.setZero();
     e[i] = Scalar(1);

--- a/sophus/se3.hpp
+++ b/sophus/se3.hpp
@@ -908,7 +908,7 @@ class SE3 : public SE3Base<SE3<Scalar_, Options>> {
   /// Precondition: ``i`` must be in [0, 5].
   ///
   SOPHUS_FUNC static Transformation generator(int i) {
-    SOPHUS_ENSURE(i >= 0 && i <= 5, "i should be in range [0,5].");
+    SOPHUS_ENSURE(i >= 0 && i <= 5, "%s", "i should be in range [0,5].");
     Tangent e;
     e.setZero();
     e[i] = Scalar(1);

--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -174,7 +174,7 @@ class SO2Base {
     using std::hypot;
     // Avoid under/overflows for higher precision
     Scalar length = hypot(unit_complex().x(), unit_complex().y());
-    SOPHUS_ENSURE(length >= Constants<Scalar>::epsilon(),
+    SOPHUS_ENSURE(length >= Constants<Scalar>::epsilon(), "%s",
                   "Complex number should not be close to zero!");
     unit_complex_nonconst() /= length;
   }

--- a/sophus/so3.hpp
+++ b/sophus/so3.hpp
@@ -693,7 +693,7 @@ class SO3 : public SO3Base<SO3<Scalar_, Options>> {
   ///
   SOPHUS_FUNC static SO3<Scalar> expAndTheta(Tangent const& omega,
                                              Scalar* theta) {
-    SOPHUS_ENSURE(theta != nullptr, "must not be nullptr.");
+    SOPHUS_ENSURE(theta != nullptr, "%s", "must not be nullptr.");
     using std::abs;
     using std::cos;
     using std::sin;
@@ -759,7 +759,7 @@ class SO3 : public SO3Base<SO3<Scalar_, Options>> {
   /// Precondition: ``i`` must be 0, 1 or 2.
   ///
   SOPHUS_FUNC static Transformation generator(int i) {
-    SOPHUS_ENSURE(i >= 0 && i <= 2, "i should be in range [0,2].");
+    SOPHUS_ENSURE(i >= 0 && i <= 2, "%s", "i should be in range [0,2].");
     Tangent e;
     e.setZero();
     e[i] = Scalar(1);


### PR DESCRIPTION
With the latest compilers (gcc 11 and up), there are errors compiling this package.  The compilers warn about variadic macros needing at least one argument.

This fixes that warning by making sure that is always the case using a %s specifier.  With this in place, the compiler warnings are gone.