### PR TITLE
Add a dependency on ceres.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ if(NOT TARGET fmt::fmt)
   find_package(fmt)
 endif()
 
+if(NOT TARGET Ceres::ceres)
+  find_package(Ceres REQUIRED)
+endif()
 
 # Define interface library target
 add_library(sophus INTERFACE)
@@ -120,6 +123,9 @@ else()
   set(fmt_DEPENDENCY "find_dependency (fmt ${fmt_VERSION})")
   message(STATUS "Turning basic logging OFF")
 endif()
+
+target_link_libraries(sophus INTERFACE Ceres::ceres)
+set(Ceres_DEPENDENCY "find_dependency (Ceres ${Ceres_VERSION})")
 
 # Associate target with include directory
 target_include_directories(sophus INTERFACE

--- a/SophusConfig.cmake.in
+++ b/SophusConfig.cmake.in
@@ -4,5 +4,6 @@ include (CMakeFindDependencyMacro)
 
 @Eigen3_DEPENDENCY@
 @fmt_DEPENDENCY@
+@Ceres_DEPENDENCY@
 
 include ("${CMAKE_CURRENT_LIST_DIR}/SophusTargets.cmake")

--- a/package.xml
+++ b/package.xml
@@ -36,6 +36,7 @@
 
   <build_depend>eigen</build_depend>
   <build_export_depend>eigen</build_export_depend>
+  <build_export_depend>libceres-dev</build_export_depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
There is a dependency on ceres for downstream consumers of sophus, so make sure to add it as an interface depend. Also add it to the package.xml.